### PR TITLE
chore: upgrade Links

### DIFF
--- a/App/Config/Global/AutoDescription.ini
+++ b/App/Config/Global/AutoDescription.ini
@@ -2,7 +2,7 @@
 Name=AutoDescription
 Rev=0.9.37
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/la-correct-zone/33168-uniformisation-des-descriptions.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=33168
 Down=https://github.com/Selphira/AutoDescription/releases/download/0.9.37/win-AutoDescription-v0.9.37.zip
 Save=win-AutoDescription-v0.9.37.zip
 Size=2999654

--- a/App/Config/Global/Derats_AutoRest.ini
+++ b/App/Config/Global/Derats_AutoRest.ini
@@ -2,7 +2,7 @@
 Name=Derat's Auto Rest
 Rev=7
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/l-atelier-du-deratiseur/33320-mod-baldur-s-gate-2-la-sauce-pillars-eternity.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=33320
 Down=https://github.com/Deratiseur/AutoRest/releases/download/v7/win-Derats_AutoRest-v7.zip
 Save=win-Derats_AutoRest-v7.zip
 Size=1280900

--- a/App/Config/Global/Derats_Magasin_2.ini
+++ b/App/Config/Global/Derats_Magasin_2.ini
@@ -2,7 +2,7 @@
 Name=L'interplan, un magasin dedie à la magie
 Rev=8.1.1
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/l-atelier-du-deratiseur/31563-magasin-l-interplan-un-magasin-dedie-la-magie.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=31563
 Down=https://github.com/Deratiseur/Interplan/archive/refs/tags/v8.1.1.zip
 Save=Interplan-8.1.1.zip
 Size=45845886

--- a/App/Config/Global/Derats_Todd.ini
+++ b/App/Config/Global/Derats_Todd.ini
@@ -2,7 +2,7 @@
 Name=Todd le super Gars testeur
 Rev=9.1
 Type=E
-Link=https://www.baldursgateworld.fr/lacouronne/l-atelier-du-deratiseur/31924-marchand-todd-le-super-gars-testeur.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=31924
 Down=https://github.com/Deratiseur/Todd/releases/download/v9.1/win-Derats_Todd-v9.1.zip
 Save=win-Derats_Todd-v9.1.zip
 Size=2525166

--- a/App/Config/Global/Lysre.ini
+++ b/App/Config/Global/Lysre.ini
@@ -2,7 +2,7 @@
 Name=Lysre, la dragonne de poche
 Rev=1.2
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/idees/25036-npc-klare.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=25036
 Down=https://drive.google.com/drive/folders/1th1e5fmZQDAqQI7tSPH5lKyi_rXiZ4ps
 Save=Lysre 1.2.rar
 Size=9783442

--- a/App/Config/Global/alcool.ini
+++ b/App/Config/Global/alcool.ini
@@ -2,7 +2,7 @@
 Name=Alcool
 Rev=0.14
 Type=S,T,E
-Link=http://www.baldursgateworld.fr/lacouronne/les-pepites-de-cespenar/11730-delire-consommations-dans-les-tavernes.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=24079
 Down=https://github.com/The-Gate-Project/Alcool/releases/download/v0.14/alcool-v0.14.zip
 Save=alcool-v0.14.zip
 Size=3304996

--- a/App/Config/Global/assassinations.ini
+++ b/App/Config/Global/assassinations.ini
@@ -2,7 +2,7 @@
 Name=Assassinations
 Rev=19
 Type=R,S,T,E
-Link=http://www.pocketplane.net/assassinations
+Link=https://www.pocketplane.net/assassinations/
 Down=https://github.com/Pocket-Plane-Group/Assassinations/archive/refs/heads/master.zip
 Save=Assassinations-master.zip
 Size=8673242

--- a/App/Config/Global/atp.ini
+++ b/App/Config/Global/atp.ini
@@ -2,7 +2,7 @@
 Name=Anomaly Tweak Pack
 Rev=3.0
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/le-bazar-de-l-aventurier/24228-atp-nouveau-mod-anomaly-tweak-pack-v3-0-a.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=24228
 Down=http://www.anomaly-studios.fr/mods/atp/ATP-v3.0.zip
 Save=ATP-v3.0.zip
 Size=910275

--- a/App/Config/Global/backbrynnlaw.ini
+++ b/App/Config/Global/backbrynnlaw.ini
@@ -2,7 +2,7 @@
 Name=Back to Brynnlaw
 Rev=9
 Type=R,S,T,E
-Link=http://www.pocketplane.net/brynnlaw
+Link=https://www.pocketplane.net/back-to-brynnlaw/
 Down=https://github.com/Pocket-Plane-Group/Back_to_Brynnlaw/releases/download/v9/back-to-brynnlaw-mod-for-baldurs-gate-ii-bgii-bgt-bgiiee-and-eet-v9.zip
 Save=back-to-brynnlaw-mod-for-baldurs-gate-ii-bgii-bgt-bgiiee-and-eet-v9.zip
 Size=7878510

--- a/App/Config/Global/banterpack.ini
+++ b/App/Config/Global/banterpack.ini
@@ -2,7 +2,7 @@
 Name=Banter Packs
 Rev=18
 Type=R,S,T,E
-Link=http://www.pocketplane.net/banter
+Link=https://www.pocketplane.net/banter-packs/
 Down=https://github.com/Pocket-Plane-Group/Banter_Pack/releases/download/v18/banter-packs-v18.zip
 Save=banter-packs-v18.zip
 Size=5289013

--- a/App/Config/Global/bg1ub.ini
+++ b/App/Config/Global/bg1ub.ini
@@ -2,7 +2,7 @@
 Name=BG1 Unfinished Business
 Rev=16.4
 Type=R,S,T,E
-Link=http://www.pocketplane.net/bg1ub
+Link=https://www.pocketplane.net/bg1-unfinished-business/
 Down=https://github.com/Pocket-Plane-Group/bg1ub/releases/download/v16.4/bg1-unfinished-business-v16.4.zip
 Save=bg1-unfinished-business-v16.4.zip
 Size=17009290

--- a/App/Config/Global/bolsa.ini
+++ b/App/Config/Global/bolsa.ini
@@ -2,7 +2,7 @@
 Name=Bolsa
 Rev=6.0.0
 Type=S,T,E
-Link=http://www.shsforums.net/files/file/772-bolsa-v41/
+Link=http://www.shsforums.net/files/file/772-bolsa/
 Down=https://github.com/Spellhold-Studios/Bolsa/releases/download/v6.0.0/bolsa-v6.0.0.zip
 Save=bolsa-v6.0.0.zip
 Size=4299241

--- a/App/Config/Global/branwen.ini
+++ b/App/Config/Global/branwen.ini
@@ -2,7 +2,7 @@
 Name=Branwen BG2 NPC
 Rev=8
 Type=S,T,E
-Link=http://forums.pocketplane.net/index.php/topic,28623.0.html
+Link=https://forums.pocketplane.net/index.php/topic,28623.0.html
 Down=https://github.com/Pocket-Plane-Group/Branwen_for_BGII/releases/download/v8/branwen-v8pre.zip
 Save=branwen-v8pre.zip
 Size=13926210

--- a/App/Config/Global/cassius.ini
+++ b/App/Config/Global/cassius.ini
@@ -2,7 +2,7 @@
 Name=Cassius le skalde
 Rev=1.6
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/viewtopic.php?p=231482&hilit=cassius#p231482
+Link=https://www.baldursgateworld.fr/viewtopic.php?p=231482
 Down=https://github.com/Plutonium-X/1D_NPC_Cassius/archive/refs/tags/v1.6.zip
 Save=1D_NPC_Cassius-1.6.zip
 Size=2955246

--- a/App/Config/Global/correctfrbg1ee.ini
+++ b/App/Config/Global/correctfrbg1ee.ini
@@ -2,7 +2,7 @@
 Name=Correction de la traduction de Baldur's Gate : Enhanced Edition
 Rev=0.10
 Type=F,R,S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/correction-de-la-traduction-de-baldur-s-gate-ii-enhanced-edition/33428-presentation-du-mod.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=33797
 Down=https://github.com/r-e-d/correctfrBG1EE/releases/download/0.10/correctfrbg1ee-0.10.zip
 Save=correctfrbg1ee-0.10.zip
 Size=206193134

--- a/App/Config/Global/correctfrbg2ee.ini
+++ b/App/Config/Global/correctfrbg2ee.ini
@@ -2,7 +2,7 @@
 Name=Correction de la traduction de Baldur's Gate II : Enhanced Edition
 Rev=0.23
 Type=F,R,S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/correction-de-la-traduction-de-baldur-s-gate-ii-enhanced-edition/33428-presentation-du-mod.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=33428
 Down=https://github.com/r-e-d/correctfrBG2EE/releases/download/0.23/correctfrbg2ee-0.23.zip
 Save=correctfrbg2ee-0.23.zip
 Size=404284376

--- a/App/Config/Global/d0questpack.ini
+++ b/App/Config/Global/d0questpack.ini
@@ -2,7 +2,7 @@
 Name=Ding0's Quest Pack
 Rev=3.5
 Type=S,T,E
-Link=http://www.pocketplane.net/quest
+Link=https://www.pocketplane.net/quest-pack/
 Down=http://mods.pocketplane.net/questpack-v35-win.zip
 Save=questpack-v35-win.zip
 Size=21707615

--- a/App/Config/Global/darron.ini
+++ b/App/Config/Global/darron.ini
@@ -2,7 +2,7 @@
 Name=Darron
 Rev=2.0.0
 Type=S,T,E
-Link=http://www.shsforums.net/files/file/842-darron-v16/
+Link=http://www.shsforums.net/files/file/842-darron/
 Down=https://github.com/Spellhold-Studios/Darron/releases/download/v2.0.0/darron-v2.0.0.zip
 Save=darron-v2.0.0.zip
 Size=4530605

--- a/App/Config/Global/dc.ini
+++ b/App/Config/Global/dc.ini
@@ -2,7 +2,7 @@
 Name=Dungeon Crawl
 Rev=13.1
 Type=S,T,E
-Link=http://www.pocketplane.net/dc
+Link=https://www.pocketplane.net/dungeon-crawl/
 Down=https://github.com/Pocket-Plane-Group/Dungeon_Crawl/releases/download/v13.1/DungeonCrawl_v13-1.zip
 Save=DungeonCrawl_v13-1.zip
 Size=11617122

--- a/App/Config/Global/dearnise.ini
+++ b/App/Config/Global/dearnise.ini
@@ -2,7 +2,7 @@
 Name=de'Arnise Romance
 Rev=7
 Type=R,S,T,E
-Link=http://www.pocketplane.net/nalia
+Link=https://www.pocketplane.net/dearnise-romance/
 Down=https://github.com/Pocket-Plane-Group/deArnise_Romance/releases/download/v7/deArnise_v7.zip
 Save=deArnise_v7.zip
 Size=8998803 

--- a/App/Config/Global/derats_kits.ini
+++ b/App/Config/Global/derats_kits.ini
@@ -2,7 +2,7 @@
 Name=Derat's Unused Kits Pack
 Rev=18.1
 Type=S,T,E,M
-Link=http://www.baldursgateworld.fr/lacouronne/la-zone-de-telechargement/24001-mods-crees-kit-derats-unused-kits-pack-v11.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=24001
 Down=https://github.com/Deratiseur/DUKP/archive/refs/tags/v18.1.zip
 Save=DUKP-18.1.zip
 Size=32396473

--- a/App/Config/Global/finchnpc.ini
+++ b/App/Config/Global/finchnpc.ini
@@ -2,7 +2,7 @@
 Name=Finch NPC
 Rev=6.0
 Type=R,S,T,E
-Link=http://www.pocketplane.net/tutumods
+Link=https://www.pocketplane.net/bg1tutu-enhancements/
 Down=https://github.com/Pocket-Plane-Group/Finch_NPC/releases/download/v6.0/finch-npc-mod-v6.0.zip
 Save=finch-npc-mod-v6.0.zip
 Size=7719279

--- a/App/Config/Global/fr_ombre.ini
+++ b/App/Config/Global/fr_ombre.ini
@@ -2,7 +2,7 @@
 Name=Rodeur de l'ombre
 Rev=1.2
 Type=S,T,E
-Link=http://www.baldursgateworld.fr/lacouronne/la-zone-de-telechargement/23996-mods-crees-kit-rodeur-de-lombre-v1-0-a.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=23996
 Down=https://github.com/GwendolyneFreddy/Rodeur_Ombre/releases/download/v1.2/rodeur-de-lombre-v1.2.zip
 Save=rodeur-de-lombre-v1.2.zip
 Size=4696810

--- a/App/Config/Global/garrick-tt.ini
+++ b/App/Config/Global/garrick-tt.ini
@@ -2,7 +2,7 @@
 Name=Garrick - Tales of a Troubadour
 Rev=1.27
 Type=S,T,E
-Link=http://mirandir.baldursgateworld.fr/garrick-tt/
+Link=https://mirandir.baldursgateworld.fr/garrick-tt/fr.html
 Down=https://github.com/The-Gate-Project/Garrick_Tales-of-a-Troubadour/releases/download/v1.27/garrick-tales-of-a-troubadour-1.27.zip
 Save=garrick-tales-of-a-troubadour-1.27.zip
 Size=7804083

--- a/App/Config/Global/hanna.ini
+++ b/App/Config/Global/hanna.ini
@@ -2,7 +2,7 @@
 Name=Hanna NPC
 Rev=2.5
 Type=S,T,E
-Link=http://www.shsforums.net/files/file/821-hanna-pnj-v24/
+Link=http://www.shsforums.net/files/file/821-hanna-pnj/
 Down=http://www.shsforums.net/files/download/821-hanna-pnj/
 Save=Hanna PNJ v2.5.zip
 Size=9751132

--- a/App/Config/Global/improvedsummons.ini
+++ b/App/Config/Global/improvedsummons.ini
@@ -2,8 +2,8 @@
 Name=Improved Summons
 Rev=2.03
 Type=T,E
-Link=http://www.sorcerers.net/Games/BG2/index_mods_hosted_misc.php
-Down=http://www.sorcerers.net/Games/dl.php?s=BG2&f=BG2/Improved_Summons.rar&download=yes
+Link=https://www.sorcerers.net/Games/BG2/index_mods_hosted_misc.php
+Down=https://www.sorcerers.net/Games/dl.php?s=BG2&f=BG2/Improved_Summons.rar&download=yes
 Save=Improved_Summons.rar
 Size=470742
 Tra=CH:0,EN:1,FR:2,RU:3,SP:4

--- a/App/Config/Global/indinpc.ini
+++ b/App/Config/Global/indinpc.ini
@@ -2,7 +2,7 @@
 Name=Indira NPC
 Rev=15
 Type=S,T,E
-Link=http://forums.pocketplane.net/index.php/topic,29214.0.html
+Link=https://forums.pocketplane.net/index.php/topic,29214.0.html
 Down=https://github.com/Pocket-Plane-Group/Indira_NPC/releases/download/v15/indira-npc-mod-v15.zip
 Save=indira-npc-mod-v15.zip
 Size=8564415

--- a/App/Config/Global/keto.ini
+++ b/App/Config/Global/keto.ini
@@ -2,7 +2,7 @@
 Name=Keto NPC (SoA)
 Rev=6
 Type=R,S,T,E
-Link=http://www.pocketplane.net/keto
+Link=https://www.pocketplane.net/keto-npc/
 Down=https://github.com/Pocket-Plane-Group/Keto/releases/download/v6/Keto-SoAv6.zip
 Save=Keto-SoAv6.zip
 Size=27391373

--- a/App/Config/Global/merskstore.ini
+++ b/App/Config/Global/merskstore.ini
@@ -2,7 +2,7 @@
 Name=Mersetek le Joaillier
 Rev=1.3.2
 Type=S,T,E
-Link=http://www.baldursgateworld.fr/lacouronne/les-pepites-de-cespenar/12721-personnage-non-joueur-mersetek-le-joaillier.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=12721
 Down=https://github.com/Plutonium-X/SHOP_Mersetek/archive/refs/tags/1.3.2.zip
 Save=SHOP_Mersetek-1.3.2.zip
 Size=2102735

--- a/App/Config/Global/px_chantelame.ini
+++ b/App/Config/Global/px_chantelame.ini
@@ -2,7 +2,7 @@
 Name=Chantelame
 Rev=7.1
 Type=S,T,E
-Link=https://www.baldursgateworld.fr/lacouronne/la-zone-de-telechargement/24080-mods-crees-kit-chantelame-v6.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=24080
 Down=https://github.com/Plutonium-X/KIT_Chantelame/archive/refs/tags/v7.1.zip
 Save=KIT_Chantelame-7.1.zip
 Size=1511653

--- a/App/Config/Global/rolles.ini
+++ b/App/Config/Global/rolles.ini
@@ -2,7 +2,7 @@
 Name=Rolles
 Rev=5.0.5
 Type=S,T,E
-Link=http://www.shsforums.net/topic/56077-rolles-v3a/
+Link=http://www.shsforums.net/topic/36655-rolles-v505/
 Down=https://github.com/Spellhold-Studios/Rolles/releases/download/v5.0.5/rolles-safyer-v5.0.5.zip
 Save=rolles-safyer-v5.0.5.zip
 Size=5165236

--- a/App/Config/Global/ruad.ini
+++ b/App/Config/Global/ruad.ini
@@ -2,7 +2,7 @@
 Name=Ruad Ro'fhessa Item Upgrade
 Rev=29.4.0
 Type=S,T,E
-Link=http://www.shsforums.net/files/file/790-ruad-rofhessa-item-upgrade-v27/
+Link=http://www.shsforums.net/files/file/790-ruad-rofhessa-item-upgrade/
 Down=https://github.com/Spellhold-Studios/Ruad-Rofhessa-Item-Upgrade/releases/download/v29.4.0/ruad-rofhessa-item-upgrade-v29.4.0.zip
 Save=ruad-rofhessa-item-upgrade-v29.4.0.zip
 Size=5293225

--- a/App/Config/Global/sellswords.ini
+++ b/App/Config/Global/sellswords.ini
@@ -2,7 +2,7 @@
 Name=The Sellswords
 Rev=9.1
 Type=R,S,T,E
-Link=http://www.pocketplane.net/sellswords
+Link=https://www.pocketplane.net/the-sellswords/
 Down=https://github.com/Pocket-Plane-Group/Sellswords/releases/download/v9.1/the-sellswords-mod-for-baldurs-gate-ii-v9.1.zip
 Save=the-sellswords-mod-for-baldurs-gate-ii-v9.1.zip
 Size=26446268

--- a/App/Config/Global/sirinescall.ini
+++ b/App/Config/Global/sirinescall.ini
@@ -2,7 +2,7 @@
 Name=Lure of the Sirine's Call
 Rev=16.4
 Type=R,S,T,E
-Link=http://www.pocketplane.net/tutumods
+Link=https://www.pocketplane.net/bg1tutu-enhancements/
 Down=https://github.com/Pocket-Plane-Group/Lure_Of_Sirines_Call/archive/refs/heads/master.zip
 Save=Lure_Of_Sirines_Call-master.zip
 Size=55442156

--- a/App/Config/Global/thoghma.ini
+++ b/App/Config/Global/thoghma.ini
@@ -2,7 +2,7 @@
 Name=Au service d'Oghma
 Rev=1.8
 Type=S,T,E
-Link=http://www.baldursgateworld.fr/lacouronne/les-pepites-de-cespenar/13198-quete-au-service-doghma.html
+Link=https://www.baldursgateworld.fr/viewtopic.php?t=13198
 Down=https://github.com/Plutonium-X/Quete_Oghma/releases/download/v1.8/win-thoghma-v1.8.zip
 Save=win-thoghma-v1.8.zip
 Size=2096075

--- a/App/Config/Global/tiax.ini
+++ b/App/Config/Global/tiax.ini
@@ -2,7 +2,7 @@
 Name=Tiax NPC
 Rev=6
 Type=S,T,E
-Link=http://forums.pocketplane.net/index.php/topic,23660.0.html
+Link=https://forums.pocketplane.net/index.php/topic,23660.0.html
 Down=https://github.com/Pocket-Plane-Group/Tiax_for_BGII/releases/download/v6/Tiax_v6.zip
 Save=Tiax_v6.zip
 Size=8304518

--- a/App/Config/Global/ub.ini
+++ b/App/Config/Global/ub.ini
@@ -2,7 +2,7 @@
 Name=Unfinished Business
 Rev=29
 Type=R,S,T,E
-Link=http://www.pocketplane.net/ub
+Link=https://www.pocketplane.net/unfinished-business/
 Down=https://github.com/Pocket-Plane-Group/UnfinishedBusiness/archive/refs/heads/master.zip
 Save=UnfinishedBusiness-master.zip
 Size=5662765

--- a/App/Config/Global/warslingsniperkit.ini
+++ b/App/Config/Global/warslingsniperkit.ini
@@ -2,8 +2,8 @@
 Name=Warsling Sniper Kit
 Rev=2.2
 Type=S,T,E
-Link=https://github.com/The-Gate-Project/WarslingSniperKit
-Down=https://github.com/The-Gate-Project/WarslingSniperKit/archive/refs/heads/main.zip
+Link=https://github.com/11jo/WarslingSniperKit
+Down=https://github.com/11jo/WarslingSniperKit/archive/refs/heads/main.zip
 Save=WarslingSniperKit-main.zip
 Size=2052699
 Tra=EN:0,FR:1

--- a/App/Config/Global/xan.ini
+++ b/App/Config/Global/xan.ini
@@ -2,7 +2,7 @@
 Name=Xan NPC
 Rev=19
 Type=S,T,E
-Link=http://www.pocketplane.net/xan
+Link=https://www.pocketplane.net/xan-bg2-npc/
 Down=https://github.com/Pocket-Plane-Group/Xan_for_BGII/releases/download/v19/Xan_v19.zip
 Save=Xan_v19.zip
 Size=74295924

--- a/App/Config/Global/xanbg1friend.ini
+++ b/App/Config/Global/xanbg1friend.ini
@@ -2,7 +2,7 @@
 Name=Xan's Friendship Path for BG1
 Rev=11
 Type=R,S,T,E
-Link=http://www.pocketplane.net/tutumods
+Link=https://www.pocketplane.net/bg1tutu-enhancements/
 Down=https://github.com/Pocket-Plane-Group/Xan_BG1_Friendship/releases/download/v11/xanbg1friend_v11.zip
 Save=xanbg1friend_v11.zip
 Size=6700740


### PR DESCRIPTION
Une mise à jour des Link. La plupart du temps ce ne sont que des redirections.
En cherchant à compléter la liste en cherchant les différences entre elle et le bws, certaines erreurs remontent juste parce que certains liens n'ont pas été mis à jour depuis longtemps (notamment pour la CC et pour pocketplane)

En plus, il y a :
http://mods.chosenofmystra.net/vampiretales/index.html et http://mods.chosenofmystra.net/encounters/index.html qui sont down, mais pour lesquels je n'ai pas de remplaçant.

http://www.baldursgateworld.fr/lacouronne/severian-de-demerya n'existe plus.